### PR TITLE
Fix Overscrolling Issues

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
 
   <body>
 
-    <nav class="navbar navbar-static-top navbar-right" >
+    <nav class="navbar navbar-static-top" >
       <div class="container-fluid">
         <div class="navbar-header">
           <button type="button"
@@ -52,7 +52,7 @@
           </a>
          -->
         </div>
-        <div id="navbar" class="collapse navbar-collapse">
+        <div id="navbar" class="collapse navbar-collapse navbar-right">
           <ul class="nav navbar-nav">
             <li {% if page.url == '/' %} class="active"{% endif %}><a href="/">About</a></li>
             <li {% if page.url == '/buy/' %} class="active"{% endif %}><a href="/buy">Buy</a></li>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ title: About
 <div class="container marketing">
   <div class="row featurette">
     <div class="col-md-8 col-md-offset-2">
-      <div id="logo"/>
+      <div id="logo"></div>
     </div>
   </div>
   <div class="row featurette">


### PR DESCRIPTION
- Bootstrap wants that `navbar-right` class on a sub-div, not the root `nav`
- Someone was having trouble with self-closing divs for some reason (either jekyll or chrome)